### PR TITLE
Add optional data refresh handling for FinGraph pipeline

### DIFF
--- a/fingraph-project/run_fingraph.py
+++ b/fingraph-project/run_fingraph.py
@@ -2,10 +2,10 @@
 FinGraph Main Integration Script
 """
 
+import argparse
 import sys
 import os
 import logging
-from datetime import datetime
 
 # Add src to path to use YOUR existing modules
 sys.path.append(os.path.join(os.path.dirname(__file__), 'src'))
@@ -20,21 +20,57 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
-def main():
+def parse_args(argv=None):
+    """Parse command-line arguments for the pipeline runner."""
+
+    parser = argparse.ArgumentParser(description="Run the FinGraph integration pipeline")
+    parser.add_argument(
+        "--refresh-data",
+        action="store_true",
+        help="Collect fresh raw data before loading and ensure cached files are up to date.",
+    )
+    parser.add_argument(
+        "--data-max-age-hours",
+        type=int,
+        default=24,
+        help="Maximum age (in hours) allowed for existing raw data before triggering a refresh.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv=None):
     """
     Run complete FinGraph pipeline using YOUR existing components
     """
+    args = parse_args(argv)
+
     print("🚀 FinGraph Integration Pipeline")
     print("=" * 50)
     print("Using your existing temporal integration system...")
-    
+
     try:
+        if args.refresh_data:
+            print("\n🔄 Refreshing raw data before pipeline execution...")
+            try:
+                from scripts.collect_data import FinGraphDataCollector
+
+                collector = FinGraphDataCollector()
+                collector.collect_all_data()
+                print("✅ Fresh data collected and saved to disk.")
+            except Exception as exc:
+                logger.exception("Failed to collect fresh data")
+                print(f"❌ Data collection failed: {exc}")
+                return False
+
         # Use YOUR existing FinGraphTemporalIntegrator
-        integrator = FinGraphTemporalIntegrator()
-        
+        integrator = FinGraphTemporalIntegrator(
+            ensure_fresh_data=args.refresh_data,
+            max_data_age_hours=args.data_max_age_hours,
+        )
+
         print("\n📋 Pipeline Steps:")
         print("1. Load existing FinGraph data")
-        print("2. Run temporal analysis") 
+        print("2. Run temporal analysis")
         print("3. Build enhanced graph")
         print("4. Generate risk predictions")
         print("5. Save results for dashboard/API")


### PR DESCRIPTION
## Summary
- add optional refresh support to `GraphDataLoader` that checks file ages, optionally collects fresh data, and logs missing optional datasets
- allow `FinGraphTemporalIntegrator` to configure automatic data refresh and pass max-age thresholds to the loader
- extend `run_fingraph.py` with CLI flags to refresh data via the collector before running the pipeline

## Testing
- python -m compileall fingraph-project/src fingraph-project/run_fingraph.py

------
https://chatgpt.com/codex/tasks/task_e_68c879b2a8d88326885bd8c5b63547f4