### PR TITLE
Persist predictions and support stored data flows

### DIFF
--- a/fingraph-project/src/visualization/dashboard.py
+++ b/fingraph-project/src/visualization/dashboard.py
@@ -7,7 +7,6 @@ import pandas as pd
 import numpy as np
 import plotly.express as px
 import plotly.graph_objects as go
-import json
 import os
 import requests
 import sys
@@ -25,13 +24,63 @@ st.set_page_config(
 )
 
 class FinGraphDashboard:
-    """Robust dashboard that connects to live API"""
+    """Dashboard capable of using live API data or stored temporal predictions."""
     
     def __init__(self):
         self.api_base_url = "https://fingraph-production.up.railway.app"
         self.risk_data = None
         self.dashboard_summary = None
-    
+        self.local_predictions_path = os.path.join(project_root, 'data', 'temporal_integration', 'predictions.csv')
+        self.data_source = None
+
+    def _categorize_risk(self, risk_score):
+        if risk_score >= 0.7:
+            return 'High'
+        elif risk_score >= 0.4:
+            return 'Medium'
+        return 'Low'
+
+    def _prepare_predictions_dataframe(self, df):
+        prepared = df.copy()
+        prepared['symbol'] = prepared['symbol'].astype(str)
+        prepared['risk_score'] = pd.to_numeric(prepared['risk_score'], errors='coerce')
+        prepared = prepared[prepared['risk_score'].notnull()]
+
+        if 'risk_level' not in prepared.columns:
+            prepared['risk_level'] = prepared['risk_score'].apply(self._categorize_risk)
+
+        if 'volatility' not in prepared.columns:
+            prepared['volatility'] = np.nan
+
+        if 'last_updated' not in prepared.columns:
+            if 'prediction_date' in prepared.columns:
+                prepared['last_updated'] = prepared['prediction_date']
+            else:
+                prepared['last_updated'] = datetime.now().isoformat()
+
+        return prepared
+
+    def _build_summary_from_df(self, df):
+        if 'last_updated' in df.columns:
+            last_updated_series = pd.to_datetime(df['last_updated'], errors='coerce').dropna()
+            timestamp = last_updated_series.max().isoformat() if not last_updated_series.empty else datetime.now().isoformat()
+        else:
+            timestamp = datetime.now().isoformat()
+
+        summary = {
+            'timestamp': timestamp,
+            'risk_overview': {
+                'total_companies': len(df),
+                'high_risk_count': int((df['risk_level'] == 'High').sum()),
+                'medium_risk_count': int((df['risk_level'] == 'Medium').sum()),
+                'low_risk_count': int((df['risk_level'] == 'Low').sum()),
+                'average_risk_score': float(df['risk_score'].mean()) if not df.empty else 0.0
+            },
+            'model_performance': {}
+        }
+
+        return summary
+
     def test_api_connection(self):
         """Test API connectivity and return status"""
         try:
@@ -42,7 +91,7 @@ class FinGraphDashboard:
                 return False, f"API returned status {response.status_code}"
         except requests.exceptions.RequestException as e:
             return False, f"Connection failed: {str(e)}"
-    
+
     def load_live_data(self):
         """Load data directly from live API - no fallbacks"""
         try:
@@ -84,44 +133,86 @@ class FinGraphDashboard:
             st.info(f"📊 Loaded live data: {len(risk_df)} companies, updated {dashboard_summary['timestamp'][:19]}")
             
             return {'summary': dashboard_summary, 'predictions': risk_df}, None
-            
+
         except requests.exceptions.RequestException as e:
             return None, f"Network error: {str(e)}"
         except Exception as e:
             return None, f"Data processing error: {str(e)}"
+
+    def load_local_results(self):
+        """Load locally stored temporal integration results"""
+        if not os.path.exists(self.local_predictions_path):
+            return None, "Predictions file not found"
+
+        try:
+            predictions_df = pd.read_csv(self.local_predictions_path)
+            if predictions_df.empty:
+                return None, "Predictions file is empty"
+
+            prepared_df = self._prepare_predictions_dataframe(predictions_df)
+            if prepared_df.empty:
+                return None, "Predictions data did not contain valid rows"
+
+            summary = self._build_summary_from_df(prepared_df)
+
+            return {'summary': summary, 'predictions': prepared_df}, None
+        except Exception as e:
+            return None, f"Failed to load stored predictions: {str(e)}"
     
     def render_header(self):
         """Header with live API status"""
         st.markdown("# 📊 FinGraph Dashboard")
-        st.markdown("### Financial Risk Assessment - Live Data")
-        
-        # Show API connection status
-        connected, status_data = self.test_api_connection()
-        if connected:
+        source_titles = {
+            "Live API": "Live Data",
+            "Stored Results": "Stored Predictions"
+        }
+        st.markdown(f"### Financial Risk Assessment - {source_titles.get(self.data_source, 'Data')}")
+
+        if self.data_source == "Live API":
+            connected, status_data = self.test_api_connection()
+            if connected:
+                col1, col2, col3, col4 = st.columns(4)
+
+                with col1:
+                    st.metric("API Status", "🟢 Live")
+                with col2:
+                    st.metric("Companies", status_data.get('companies_count', 'N/A'))
+                with col3:
+                    st.metric("Data Source", "Real-time API")
+                with col4:
+                    last_update = status_data.get('last_update', '')[:19] if status_data.get('last_update') else 'Unknown'
+                    st.metric("Last Update", last_update)
+            else:
+                st.error(f"🔴 API Connection Failed: {status_data}")
+        elif self.data_source == "Stored Results":
+            overview = self.dashboard_summary.get('risk_overview', {}) if self.dashboard_summary else {}
+            timestamp = self.dashboard_summary.get('timestamp', 'Unknown') if self.dashboard_summary else 'Unknown'
+
             col1, col2, col3, col4 = st.columns(4)
-            
             with col1:
-                st.metric("API Status", "🟢 Live")
+                st.metric("Data Source", "Stored Predictions")
             with col2:
-                st.metric("Companies", status_data.get('companies_count', 'N/A'))
+                st.metric("Companies", overview.get('total_companies', 'N/A'))
             with col3:
-                st.metric("Data Source", "Real-time API")
+                st.metric("High Risk", overview.get('high_risk_count', 0))
             with col4:
-                last_update = status_data.get('last_update', '')[:10] if status_data.get('last_update') else 'Unknown'
-                st.metric("Last Update", last_update)
+                st.metric("Last Update", timestamp[:19] if timestamp else 'Unknown')
+
+            st.caption(f"Loaded from {self.local_predictions_path}")
         else:
-            st.error(f"🔴 API Connection Failed: {status_data}")
-        
+            st.info("Select a data source from the sidebar to load results.")
+
         st.markdown("---")
     
     def render_risk_table(self):
         """Risk rankings from live API data"""
-        st.markdown("## 🎯 Live Company Risk Rankings")
-        
+        source_label = "Live" if self.data_source == "Live API" else "Stored" if self.data_source == "Stored Results" else "Live"
+        st.markdown(f"## 🎯 {source_label} Company Risk Rankings")
+
         if self.risk_data is not None and not self.risk_data.empty:
             # Sort by risk score (highest first)
             df_display = self.risk_data.sort_values('risk_score', ascending=False).copy()
-            
+
             # Add risk level emoji
             risk_emoji = {'High': '🚨', 'Medium': '⚠️', 'Low': '✅'}
             df_display['Risk Level'] = df_display['risk_level'].map(risk_emoji) + ' ' + df_display['risk_level']
@@ -135,30 +226,31 @@ class FinGraphDashboard:
                 }),
                 use_container_width=True
             )
-            
+
             # Risk distribution chart from live data
             risk_counts = self.risk_data['risk_level'].value_counts()
             fig = px.pie(
                 values=risk_counts.values,
                 names=risk_counts.index,
-                title="Live Risk Distribution",
+                title=f"{source_label} Risk Distribution",
                 color_discrete_map={'High': '#ff4444', 'Medium': '#ffaa44', 'Low': '#44ff44'}
             )
             st.plotly_chart(fig, use_container_width=True)
-            
+
             # Show data timestamp
             if self.dashboard_summary and 'timestamp' in self.dashboard_summary:
                 st.caption(f"Data timestamp: {self.dashboard_summary['timestamp']}")
         else:
-            st.error("❌ No live risk data available")
+            st.error(f"❌ No {source_label.lower()} risk data available")
     
     def render_model_performance(self):
         """Model performance from live API"""
-        st.markdown("## 🤖 Live Model Performance")
-        
+        source_label = "Live" if self.data_source == "Live API" else "Stored"
+        st.markdown(f"## 🤖 {source_label} Model Performance")
+
         if self.dashboard_summary and 'model_performance' in self.dashboard_summary:
             perf = self.dashboard_summary['model_performance']
-            
+
             if perf:
                 # Create comparison table
                 models = list(perf.keys())
@@ -182,74 +274,110 @@ class FinGraphDashboard:
                 fig = px.bar(df_perf, x='Model', y='MSE', title='Live Model Performance (Lower is Better)')
                 st.plotly_chart(fig, use_container_width=True)
             else:
-                st.warning("No model performance data in API response")
+                st.info("Model performance data is not available for this data source")
         else:
-            st.error("❌ No live model performance data available")
+            st.error("❌ No model performance data available")
     
     def render_alerts(self):
         """Risk alerts from live data"""
-        st.markdown("## 🚨 Live Risk Alerts")
-        
+        source_label = "Live" if self.data_source == "Live API" else "Stored"
+        st.markdown(f"## 🚨 {source_label} Risk Alerts")
+
         if self.risk_data is not None and not self.risk_data.empty:
             # Get high risk companies
             high_risk = self.risk_data[self.risk_data['risk_level'] == 'High']
-            
+
             if len(high_risk) > 0:
                 st.error(f"🚨 {len(high_risk)} companies at HIGH RISK:")
                 for _, row in high_risk.iterrows():
                     st.markdown(f"- **{row['symbol']}**: Risk Score {row['risk_score']:.3f}")
             else:
                 st.success("✅ No high risk companies detected")
-            
+
             # Dynamic risk threshold
             threshold = st.slider("Risk Alert Threshold", 0.0, 1.0, 0.7, 0.05)
             alerts = self.risk_data[self.risk_data['risk_score'] >= threshold]
-            
+
             if len(alerts) > 0:
                 st.warning(f"⚠️ {len(alerts)} companies above {threshold:.2f} threshold")
                 for _, row in alerts.iterrows():
                     st.text(f"{row['symbol']}: {row['risk_score']:.3f}")
         else:
-            st.error("❌ No live risk data for alerts")
+            st.error(f"❌ No {source_label.lower()} risk data for alerts")
     
     def run(self):
-        """Main dashboard execution - loads live data only"""
-        
-        # Force fresh data load on every run (no caching of static data)
-        with st.spinner("🔄 Loading live data from API..."):
-            results, error = self.load_live_data()
-        
-        if error:
-            st.error(f"❌ Failed to load live data: {error}")
+        """Main dashboard execution supporting multiple data sources."""
+        st.sidebar.header("Data Source")
+        mode = st.sidebar.radio(
+            "Preferred source",
+            ["Auto", "Stored Results", "Live API"],
+            index=0
+        )
+        st.sidebar.caption("Auto loads stored predictions when available and falls back to the live API if needed.")
+
+        stored_error = None
+        api_error = None
+        results = None
+        actual_source = None
+
+        with st.spinner("🔄 Loading risk data..."):
+            if mode == "Stored Results":
+                results, stored_error = self.load_local_results()
+                actual_source = "Stored Results"
+            elif mode == "Live API":
+                results, api_error = self.load_live_data()
+                actual_source = "Live API"
+            else:  # Auto
+                results, stored_error = self.load_local_results()
+                if results:
+                    actual_source = "Stored Results"
+                else:
+                    results, api_error = self.load_live_data()
+                    actual_source = "Live API" if results else None
+
+        if results is None:
+            if mode == "Auto" and stored_error and api_error:
+                st.error("❌ Failed to load both stored predictions and live API data.")
+                st.markdown(f"- Stored predictions error: {stored_error}")
+                st.markdown(f"- Live API error: {api_error}")
+            else:
+                message = stored_error or api_error or "Unknown error"
+                st.error(f"❌ Failed to load data: {message}")
+
             st.markdown("""
             ### 🔧 Troubleshooting:
+            - Ensure temporal integration predictions are saved locally
             - Check if API is running: https://fingraph-production.up.railway.app/health
             - Verify network connectivity
             - Try refreshing the page
             """)
             return
-        
-        # Store live data
-        if results:
-            self.dashboard_summary = results['summary']
-            self.risk_data = results['predictions']
-        
-        # Render dashboard with live data
+
+        # Store loaded data
+        self.dashboard_summary = results['summary']
+        self.risk_data = results['predictions']
+        self.data_source = actual_source
+
+        if mode == "Auto" and actual_source == "Live API" and stored_error:
+            st.warning(f"Stored predictions unavailable ({stored_error}). Loaded live API data instead.")
+
+        # Render dashboard with selected data source
         self.render_header()
-        
+
         tab1, tab2, tab3 = st.tabs(["🎯 Risk Overview", "🤖 Model Performance", "🚨 Alerts"])
-        
+
         with tab1:
             self.render_risk_table()
-        
+
         with tab2:
             self.render_model_performance()
-        
+
         with tab3:
             self.render_alerts()
-        
-        # Refresh button for live updates
-        if st.button("🔄 Refresh Live Data"):
+
+        # Refresh button
+        refresh_label = "🔄 Refresh Live Data" if self.data_source == "Live API" else "🔄 Reload Stored Data"
+        if st.button(refresh_label):
             st.rerun()
 
 def main():


### PR DESCRIPTION
## Summary
- add stable temporal prediction snapshot generation so downstream services can reuse integrator output
- extend the API to serve stored predictions or fall back to live heuristics for all key endpoints
- update the Streamlit dashboard to load stored results, call the API, or auto-fallback based on availability

## Testing
- python -m compileall fingraph-project/src/models/temporal_integration.py fingraph-project/api/main.py fingraph-project/src/visualization/dashboard.py

------
https://chatgpt.com/codex/tasks/task_e_68c879b7fc608326a2901083b3670184